### PR TITLE
Remove the force-encoding to ASCII for project notes

### DIFF
--- a/comet_for_mlflow/comet_for_mlflow.py
+++ b/comet_for_mlflow/comet_for_mlflow.py
@@ -443,9 +443,7 @@ class Translator(object):
                     )
                     # We don't support Unicode project notes yet
                     self.api_client.set_project_notes(
-                        self.workspace,
-                        project_name,
-                        note_template.encode("ascii", "backslashreplace"),
+                        self.workspace, project_name, note_template,
                     )
 
                 all_project_names.append(project_name)

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md") as readme_file:
 with open("HISTORY.md") as history_file:
     history = history_file.read()
 
-requirements = ["mlflow", "comet_ml>=3.0.3", "tabulate", "tqdm", "typing"]
+requirements = ["mlflow", "comet_ml>=3.1.1", "tabulate", "tqdm", "typing"]
 
 
 setup(


### PR DESCRIPTION
The Comet SDK now support Unicode project notes in Python 2